### PR TITLE
Adds support for a new option topics.filterPolicyScope.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Call `sqns` to create an SQS queue (and deadletter queue). You will be returned 
 | ------ | ---- | ------- | ----------- |
 | `arn` | `string` | | SNS Topic ARN |
 | `filterPolicy` | `Object` | | [SNS Topic Subscription Filter Policy](https://docs.aws.amazon.com/en_pv/sns/latest/dg/sns-subscription-filter-policies.html) |
+| `filterPolicyScope` | `string` | [SNS Topic Subscription Filter Policy Scope](https://docs.aws.amazon.com/sns/latest/dg/sns-message-filtering-scope.html)
 | `rawMessageDelivery` | `Boolean` | `true` | [SNS Topic Subscription Raw Message Delivery](https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html) |
 
 ## Example Usage

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,6 +157,14 @@ const sqns = async (options: SqnsOptions): Promise<string> => {
       })
     }
 
+    if (topicOptions.filterPolicy && topicOptions.filterPolicyScope) {
+      await setSubscriptionAttributes({
+        SubscriptionArn: subscriptionArn,
+        AttributeName: 'FilterPolicyScope',
+        AttributeValue: topicOptions.filterPolicyScope
+      })
+    }
+
     if (topicOptions.rawMessageDelivery === true) {
       await setSubscriptionAttributes({
         SubscriptionArn: subscriptionArn,

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,5 +13,6 @@ export interface SqnsOptions {
 export interface TopicOptions {
   arn?: string
   filterPolicy?: Record<string, string>
+  filterPolicyScope?: 'MessageAttributes' | 'MessageBody'
   rawMessageDelivery?: boolean
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -366,6 +366,26 @@ describe('sqns', () => {
           })
           expect(queueUrl).to.equal('mock-queue-url')
         })
+
+        context('when topic filterPolicyScope is also provided', () => {
+          it('sets FilterPolicyScope attribute', async () => {
+            await sqns({
+              region: 'us-east-1',
+              queueName: 'queue',
+              topic: {
+                arn: 'mock-sns-topic-arn',
+                filterPolicy: { mock: 'filter-policy' },
+                filterPolicyScope: 'MessageAttributes',
+              }
+            })
+
+            expect(setSubscriptionAttributesStub).to.have.been.calledWith({
+              SubscriptionArn: 'mock-subscription-arn',
+              AttributeName: 'FilterPolicyScope',
+              AttributeValue: 'MessageAttributes',
+            })
+          })
+        })
       })
 
       context('when topic rawMessageDelivery is false', () => {


### PR DESCRIPTION
When set it will set the FilterPolicyScope attribute on the subscription.

We are wanting to add support for this because we are wanting to filter messages on the message body.