### PR TITLE
Fix ability to create a nested filter policy for MessageBody filters

### DIFF
--- a/.changeset/beige-poems-occur.md
+++ b/.changeset/beige-poems-occur.md
@@ -1,0 +1,5 @@
+---
+"@articulate/sqns": patch
+---
+
+This fixes a bug where you could not create a `MessageBody` policy with nesting on initial creation of the topic filter policy.

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,19 +149,19 @@ const sqns = async (options: SqnsOptions): Promise<string> => {
     const subscriptionArn = await createTopicSubscription(queueArn, topicOptions.arn)
     await setSqsQueueAttributes(queueUrl, queueArn, topicOptions.arn)
 
-    if (topicOptions.filterPolicy) {
-      await setSubscriptionAttributes({
-        SubscriptionArn: subscriptionArn,
-        AttributeName: 'FilterPolicy',
-        AttributeValue: JSON.stringify(topicOptions.filterPolicy)
-      })
-    }
-
     if (topicOptions.filterPolicy && topicOptions.filterPolicyScope) {
       await setSubscriptionAttributes({
         SubscriptionArn: subscriptionArn,
         AttributeName: 'FilterPolicyScope',
         AttributeValue: topicOptions.filterPolicyScope
+      })
+    }
+
+    if (topicOptions.filterPolicy) {
+      await setSubscriptionAttributes({
+        SubscriptionArn: subscriptionArn,
+        AttributeName: 'FilterPolicy',
+        AttributeValue: JSON.stringify(topicOptions.filterPolicy)
       })
     }
 


### PR DESCRIPTION
This fixes a bug where you could not create a `MessageBody` policy with nesting on initial creation of the topic filter policy.

Moves setting `FilterPolicyScope` before setting `FilterPolicy`.  This is needed because the default `FilterPolicyScope`, `MessageAttributes`, does not support policies with nesting, but `MessageBody` does.